### PR TITLE
Fix file open function (SVYX-192)

### DIFF
--- a/ngdesktopfile/ngdesktopfile/ngdesktopfile.js
+++ b/ngdesktopfile/ngdesktopfile/ngdesktopfile.js
@@ -474,7 +474,11 @@ angular.module('ngdesktopfile',['servoy'])
  			 */
 			openFile: function(path) {
 				try {
-					return shell.openItem(path);
+					if (runningElectron(900)) {
+						return shell.openPath(path);
+					} else {
+						return shell.openItem(path);
+					}
 				} catch(err) {
 					console.log(err);
 				}

--- a/ngdesktopfile/ngdesktopfile/ngdesktopfile.js
+++ b/ngdesktopfile/ngdesktopfile/ngdesktopfile.js
@@ -46,6 +46,29 @@ angular.module('ngdesktopfile',['servoy'])
 			}
 			else func();
 		}
+		function runningElectron(version) {
+			var userAgent = navigator.userAgent.toLowerCase();
+			var elAg = userAgent.indexOf('electron/');
+			if (elAg > -1) {
+				if (version) {
+					var curVersion = getCurrentVersion().replace(/\./g,'');
+					if (curVersion >= version) {
+						return true;
+					} else {
+						return false;
+					}
+				} else {
+					return true;
+				}
+			} else {
+				return false;
+			}
+		}
+		function getCurrentVersion() {
+			var userAgent = navigator.userAgent.toLowerCase();
+			var elAg = userAgent.indexOf('electron/');
+			return userAgent.substring(elAg + 9, userAgent.indexOf(' ', elAg));
+		}
 		return {
 			waitForDefered: function(func) {
 				waitForDefered(func);


### PR DESCRIPTION
The function `shell.openItem(path)` got changed to `shell.openPath(path)` in Electron version 9 and higher. See https://github.com/electron/governance/blob/master/wg-api/spec-documents/shell-openitem.md.
This will resolve the issue raised in https://support.servoy.com/browse/SVYX-192 by adding a Electron version check and than using the correct shell command.

The Electron version check relies on `navigator.userAgent` because this is more reliable than the `process` way which can be disabled by a client.

Fix has been tested using the Servoy Developer 2020.12 NGDesktop Client (Electron v11.0.3).